### PR TITLE
Change mixin module from `OperatorRecordable` to `OperatorRecordable::Extension`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Breaking changes
+
+* Change mixin module from `OperatorRecordable` to `OperatorRecordable::Extension`
+
 
 ## 0.2.0 (2018-09-27)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ OperatorRecordable.config = {
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  include OperatorRecordable
+  include OperatorRecordable::Extension
 end
 ```
 

--- a/lib/operator_recordable.rb
+++ b/lib/operator_recordable.rb
@@ -2,7 +2,7 @@
 
 require "operator_recordable/version"
 require "operator_recordable/configuration"
-require "operator_recordable/recorder"
+require "operator_recordable/extension"
 
 module OperatorRecordable
   def self.config
@@ -21,11 +21,6 @@ module OperatorRecordable
   def self.operator=(operator)
     config.store[operator_store_key] = operator
   end
-
-  def self.included(class_or_module)
-    class_or_module.extend Recorder.new(config)
-  end
-  private_class_method :included
 
   def self.operator_store_key
     :operator_recordable_operator

--- a/lib/operator_recordable/extension.rb
+++ b/lib/operator_recordable/extension.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "operator_recordable/recorder"
+
+module OperatorRecordable
+  module Extension
+    def self.included(class_or_module)
+      class_or_module.extend Recorder.new(OperatorRecordable.config)
+    end
+    private_class_method :included
+  end
+end

--- a/spec/operator_recordable_spec.rb
+++ b/spec/operator_recordable_spec.rb
@@ -32,7 +32,7 @@ CreateAllTables.up
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  include OperatorRecordable
+  include OperatorRecordable::Extension
 end
 
 class Operator < ApplicationRecord


### PR DESCRIPTION
If a class include `OperatorRecordable` module, all constants of `OperatorRecordable` module are included in it.
I added a module for mixin to solve this.