### PR TITLE
Make associations optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ OperatorRecordable.config = {
 | `creator_association_name` | String | association name of creator. | `"creator"` |
 | `updater_association_name` | String | association name of updater. | `"updater"` |
 | `deleter_association_name` | String | association name of deleter. | `"deleter"` |
-| `operator_association_options` | Hash | options of operator associations. e.g. `{ optional: true }` | `{}` |
+| `operator_association_options` | Hash | options of operator associations. e.g. `{ touch: true }` | `{}` |
 | `operator_association_scope` | Proc | The scope of operator associations. e.g. `-> { with_deleted }`  | `nil` |
 | `store` | Enum | operator store. any value of `:thread_store`, `:request_store` or `:current_attributes_store` | `:thread_store` |
 

--- a/lib/operator_recordable/recorder.rb
+++ b/lib/operator_recordable/recorder.rb
@@ -52,7 +52,8 @@ module OperatorRecordable
       klass.belongs_to config.association_name_for(type).to_sym,
                        config.operator_association_scope,
                        **{ foreign_key: config.column_name_for(type),
-                           class_name: config.operator_class_name }.merge(config.operator_association_options)
+                           class_name: config.operator_class_name,
+                           optional: true }.merge(config.operator_association_options)
     end
 
     def define_creator_instance_methods(klass, config)


### PR DESCRIPTION
Since Rails v5, belongs_to assocition has generate a required attribute.
So it expects to filled value on validation phase.  But
operator_recoradble fills columns after validation (just before creating,
updating or deleting).  This causes operator_recordable gem are not
working by default settings.

This makes these associations optional.