### PR TITLE
Set `belongs_to_required_by_default = true` to be same as Rails default

### DIFF
--- a/spec/operator_recordable/configuration_spec.rb
+++ b/spec/operator_recordable/configuration_spec.rb
@@ -161,9 +161,9 @@ RSpec.describe OperatorRecordable::Configuration do
     end
 
     context "when operator_association_options is specified" do
-      let(:config) { { operator_association_options: { optional: true } } }
+      let(:config) { { operator_association_options: { touch: true } } }
 
-      it { is_expected.to match optional: true }
+      it { is_expected.to match touch: true }
     end
   end
 

--- a/spec/operator_recordable_spec.rb
+++ b/spec/operator_recordable_spec.rb
@@ -6,6 +6,7 @@ ActiveRecord::Base.configurations = {
   "test" => { "adapter" => "sqlite3", "database" => ":memory:" }
 }
 ActiveRecord::Base.establish_connection :test
+ActiveRecord::Base.belongs_to_required_by_default = true # default for Rails 5.0+
 
 class CreateAllTables < ActiveRecord::Migration::Current
   def self.up


### PR DESCRIPTION

ref. #28