### PR TITLE
Support discard gem for soft deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 OperatorRecordable is a Rails plugin gem that makes your ActiveRecord models to be saved or logically deleted with automatically set `created_by`, `updated_by`, and `deleted_by`.
 Also it makes `creator`, `updater`, and `deleter` `belongs_to` association if a class has `created_by`, `updated_by`, or `deleted_by`.
 
+It also supports `discarded_by` column if [discard gem](https://github.com/jhawthorn/discard) is available.
+
 This gem is inspired by [RecordWithOperator](https://github.com/nay/record_with_operator).
 
 ## Installation
@@ -38,9 +40,11 @@ OperatorRecordable.config = {
   creator_column_name: "created_by",
   updater_column_name: "updated_by",
   deleter_column_name: "deleted_by",
+  discarder_column_name: "discarded_by",
   creator_association_name: "creator",
   updater_association_name: "updater",
   deleter_association_name: "deleter",
+  discarder_association_name: "discarder",
   operator_association_options: {},
   operator_association_scope: nil,
   store: :thread_store
@@ -55,9 +59,11 @@ OperatorRecordable.config = {
 | `creator_column_name` | String | column name of creator. | `"created_by"` |
 | `updater_column_name` | String | column name of updater. | `"updated_by"` |
 | `deleter_column_name` | String | column name of deleter. | `"deleted_by"` |
+| `discarder_column_name` | String | column name of discarder. | `"discarded_by"` |
 | `creator_association_name` | String | association name of creator. | `"creator"` |
 | `updater_association_name` | String | association name of updater. | `"updater"` |
 | `deleter_association_name` | String | association name of deleter. | `"deleter"` |
+| `discarder_association_name` | String | association name of discarder. | `"discarder"` |
 | `operator_association_options` | Hash | options of operator associations. e.g. `{ touch: true }` | `{}` |
 | `operator_association_scope` | Proc | The scope of operator associations. e.g. `-> { with_deleted }`  | `nil` |
 | `store` | Enum | operator store. any value of `:thread_store`, `:request_store` or `:current_attributes_store` | `:thread_store` |

--- a/lib/operator_recordable/configuration.rb
+++ b/lib/operator_recordable/configuration.rb
@@ -11,8 +11,8 @@ module OperatorRecordable
       @store = initialize_store
     end
 
-    %i[operator_class_name creator_column_name updater_column_name deleter_column_name
-       creator_association_name updater_association_name deleter_association_name
+    %i[operator_class_name creator_column_name updater_column_name deleter_column_name discarder_column_name
+       creator_association_name updater_association_name deleter_association_name discarder_association_name
        operator_association_options operator_association_scope].each do |name|
       define_method name do
         config[name]
@@ -37,9 +37,11 @@ module OperatorRecordable
         creator_column_name: "created_by",
         updater_column_name: "updated_by",
         deleter_column_name: "deleted_by",
+        discarder_column_name: "discarded_by",
         creator_association_name: "creator",
         updater_association_name: "updater",
         deleter_association_name: "deleter",
+        discarder_association_name: "discarder",
         operator_association_options: {},
         operator_association_scope: nil,
         store: :thread_store
@@ -53,7 +55,7 @@ module OperatorRecordable
     end
 
     class Model
-      VALID_ACTIONS = %i[create update destroy].freeze
+      VALID_ACTIONS = %i[create update destroy discard].freeze
 
       def initialize(actions)
         @actions = actions
@@ -70,6 +72,10 @@ module OperatorRecordable
 
       def record_deleter?
         actions.include? :destroy
+      end
+
+      def record_discarder?
+        actions.include? :discard
       end
 
       private

--- a/operator_recordable.gemspec
+++ b/operator_recordable.gemspec
@@ -51,4 +51,5 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_development_dependency "rubocop", ">= 0.78.0"
   spec.add_development_dependency "sqlite3", ">= 1.3.13"
+  spec.add_development_dependency "discard", ">= 1.2"
 end

--- a/spec/operator_recordable/configuration_spec.rb
+++ b/spec/operator_recordable/configuration_spec.rb
@@ -103,6 +103,22 @@ RSpec.describe OperatorRecordable::Configuration do
     end
   end
 
+  describe "#discarder_column_name" do
+    subject { described_class.new(config).discarder_column_name }
+
+    context "when discarder_column_name is not specified" do
+      let(:config) { {} }
+
+      it { is_expected.to eq "discarded_by" }
+    end
+
+    context "when discarder_column_name is specified" do
+      let(:config) { { discarder_column_name: "discarded_operator_id" } }
+
+      it { is_expected.to eq "discarded_operator_id" }
+    end
+  end
+
   describe "#creator_association_name" do
     subject { described_class.new(config).creator_association_name }
 
@@ -148,6 +164,22 @@ RSpec.describe OperatorRecordable::Configuration do
       let(:config) { { deleter_association_name: "deleter_operator" } }
 
       it { is_expected.to eq "deleter_operator" }
+    end
+  end
+
+  describe "#discarder_association_name" do
+    subject { described_class.new(config).discarder_association_name }
+
+    context "when discarder_association_name is not specified" do
+      let(:config) { {} }
+
+      it { is_expected.to eq "discarder" }
+    end
+
+    context "when discarder_association_name is specified" do
+      let(:config) { { discarder_association_name: "discarded_operator" } }
+
+      it { is_expected.to eq "discarded_operator" }
     end
   end
 
@@ -207,6 +239,12 @@ RSpec.describe OperatorRecordable::Configuration do
 
         it { is_expected.to eq "deleted_by" }
       end
+
+      context "when :discarder is passed" do
+        let(:type) { :discarder }
+
+        it { is_expected.to eq "discarded_by" }
+      end
     end
 
     context "when association names are specified" do
@@ -214,7 +252,8 @@ RSpec.describe OperatorRecordable::Configuration do
         {
           creator_column_name: "creator_operator_id",
           updater_column_name: "updater_operator_id",
-          deleter_column_name: "deleter_operator_id"
+          deleter_column_name: "deleter_operator_id",
+          discarder_column_name: "discarder_operator_id"
         }
       end
 
@@ -234,6 +273,12 @@ RSpec.describe OperatorRecordable::Configuration do
         let(:type) { :deleter }
 
         it { is_expected.to eq "deleter_operator_id" }
+      end
+
+      context "when :discarder is passed" do
+        let(:type) { :discarder }
+
+        it { is_expected.to eq "discarder_operator_id" }
       end
     end
   end
@@ -261,6 +306,12 @@ RSpec.describe OperatorRecordable::Configuration do
 
         it { is_expected.to eq "deleter" }
       end
+
+      context "when :discarder is passed" do
+        let(:type) { :discarder }
+
+        it { is_expected.to eq "discarder" }
+      end
     end
 
     context "when column names are specified" do
@@ -268,7 +319,8 @@ RSpec.describe OperatorRecordable::Configuration do
         {
           creator_association_name: "creator_operator",
           updater_association_name: "updater_operator",
-          deleter_association_name: "deleter_operator"
+          deleter_association_name: "deleter_operator",
+          discarder_association_name: "discarder_operator"
         }
       end
 
@@ -288,6 +340,12 @@ RSpec.describe OperatorRecordable::Configuration do
         let(:type) { :deleter }
 
         it { is_expected.to eq "deleter_operator" }
+      end
+
+      context "when :discarder is passed" do
+        let(:type) { :discarder }
+
+        it { is_expected.to eq "discarder_operator" }
       end
     end
   end


### PR DESCRIPTION
The discard gem becomes the successor of the paranoia gem.  But it does
not work with this gem at all because it does not call "before_destroy"
hook.

This handles "before_discard" hook and store the operator as a disorder.

Nowadays, the paranoia gem is not recommended for new projects (see [their project page](https://github.com/rubysherpas/paranoia)). Therefore developers who wants to do soft deletes would choose the discard gem, I believe supporting it is much worthy for this gem.