### PR TITLE
Get rid of needless guard clauses for ActiveSupport 5.1 and older

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Support discard gem for soft deletes
   + https://github.com/yujideveloper/operator_recordable/pull/31
+* Get rid of needless guard clauses for ActiveSupport 5.1 and older
+  + https://github.com/yujideveloper/operator_recordable/pull/32
 
 
 ## 1.2.0 (2022-04-26)

--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ require "operator_recordable/store/request_store"
 
 #### `:current_attributes_store`
 
-This store is implemented by using [`ActiveSupport::CurrentAttributes`](https://api.rubyonrails.org/v5.2.0/classes/ActiveSupport/CurrentAttributes.html).  
-So, this requires ActiveSupport 5.2 or later.
+This store is implemented by using [`ActiveSupport::CurrentAttributes`](https://api.rubyonrails.org/v5.2.0/classes/ActiveSupport/CurrentAttributes.html).
 
 
 ## Development

--- a/lib/operator_recordable/store.rb
+++ b/lib/operator_recordable/store.rb
@@ -15,4 +15,4 @@ end
 
 require "operator_recordable/store/thread_store"
 require "operator_recordable/store/request_store" if defined? ::RequestStore
-require "operator_recordable/store/current_attributes_store" if defined? ::ActiveSupport::CurrentAttributes
+require "operator_recordable/store/current_attributes_store"

--- a/spec/operator_recordable/configuration_spec.rb
+++ b/spec/operator_recordable/configuration_spec.rb
@@ -31,11 +31,7 @@ RSpec.describe OperatorRecordable::Configuration do
     context "when store is :current_attributes_store" do
       let(:config) { { store: :current_attributes_store } }
 
-      if defined? ::ActiveSupport::CurrentAttributes
-        it { is_expected.to be_an_instance_of OperatorRecordable::CurrentAttributesStore }
-      else
-        it { expect { subject }.to raise_error KeyError }
-      end
+      it { is_expected.to be_an_instance_of OperatorRecordable::CurrentAttributesStore }
     end
   end
 

--- a/spec/operator_recordable/store/current_attributes_store_spec.rb
+++ b/spec/operator_recordable/store/current_attributes_store_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless defined? ::ActiveSupport::CurrentAttributes
-
 require "spec_helper"
 
 RSpec.describe OperatorRecordable::CurrentAttributesStore do


### PR DESCRIPTION
OperatorRecordable no longer supports ActiveSupport 5.1.