### PR TITLE
Fix recording discarded_by if the target table uses optimistic lock

### DIFF
--- a/lib/operator_recordable/recorder.rb
+++ b/lib/operator_recordable/recorder.rb
@@ -109,10 +109,6 @@ module OperatorRecordable
           return if self.frozen?                                     #   return if self.frozen?
           return unless (op = OperatorRecordable.operator)           #   return unless (op = OperatorRecordable.operator)
                                                                      #
-          self                                                       #   self
-            .class                                                   #     .class
-            .where(self.class.primary_key => id)                     #     .where(self.class.primary_key => id)
-            .update_all('#{config.discarder_column_name}' => op.id)  #     .update_all('discarded_by' => op.id)
           self.#{config.discarder_column_name} = op.id               #   self.discarded_by = op.id
         end                                                          # end
       END_OF_DEF

--- a/spec/operator_recordable_spec.rb
+++ b/spec/operator_recordable_spec.rb
@@ -27,6 +27,7 @@ class CreateAllTables < ActiveRecord::Migration::Current
     create_table(:posts) do |t|
       t.string :title
       t.string :body
+      t.integer :lock_version
       t.datetime :created_at
       t.integer :created_by
       t.datetime :updated_at


### PR DESCRIPTION
I found discard gem support that I proposed in https://github.com/yujideveloper/operator_recordable/pull/31 is incomplete. It does not work well if the target table uses an optimistic lock (a.k.a. lock_version).
The current implementation goes to update `discarded_by` column before discarding (on `before_discard` event). But it conflicts with the discarding via discard gem because `lock_version` will be incremented by this gem.

This simply updates the `discarded_by` column on the instance and does not update it on the database directly.  It will be stored on discarding automatically.

I don't know why the `deleted_by` column goes fine with the optimistic lock. But it seems works well even if I added `lock_version` column to the `Account` table on the spec.

Sorry for my overlook. I must appreciate your works as always :-)